### PR TITLE
Empty working directories should be created by package, not init script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,3 +25,8 @@ mkdir -p $PACKAGE_DIR
 mkdir -p $PACKAGE_DIR/usr/local/bin
 cp ./consul $PACKAGE_DIR/usr/local/bin
 cp -r $REPO_DIR/etc $PACKAGE_DIR
+
+# Create misc empty directories
+for path in /var/run/consul /var/lib/consul /etc/consul.d; do
+    mkdir -p $PACKAGE_DIR$path
+done

--- a/etc/init/consul.conf
+++ b/etc/init/consul.conf
@@ -14,24 +14,6 @@ env DATA_DIR=/var/lib/consul
 env CONFIG_FILE=/etc/consul.json
 env CONFIG_DIR=/etc/consul.d
 
-pre-start script
-	# Ensure all the directories exist
-	PID_DIR=$(dirname $PID_FILE)
-	if [ ! -d $PID_DIR ]; then
-		mkdir -p $PID_DIR
-        chown -R $USER:$GROUP $PID_DIR
-        chmod 755 $PID_DIR
-	fi
-	if [ ! -d $DATA_DIR ]; then
-		mkdir -p $DATA_DIR
-        chown -R $USER:$GROUP $DATA_DIR
-        chmod 755 $DATA_DIR
-	fi
-	if [ ! -d $CONFIG_DIR ]; then
-		mkdir -p $CONFIG_DIR
-	fi
-end script
-
 script
 	# CONSUL_OPTS can be overridden in /etc/default/consul
 	CONSUL=/usr/local/bin/consul

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -11,3 +11,9 @@ if ! getent passwd consul >/dev/null; then
             --system --shell /bin/false \
             --gecos "Consul user" consul
 fi
+
+# Set permissions for directories
+for path in /var/run/consul /var/lib/consul /etc/consul.d; do
+    chown -R consul:consul $path
+    chmod 755 $path
+done


### PR DESCRIPTION
- Directories should have perms set in postinstall
